### PR TITLE
Using console-log-div to redirect console messages to the page.

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -24,6 +24,6 @@
             System.get("app.ats" + '');
         </script>
 
-
+    <script src="bower_components/console-log-div/console-log-div.js"></script>
 </body>
 </html>

--- a/app/modules/home/math-component.html
+++ b/app/modules/home/math-component.html
@@ -18,5 +18,5 @@
     <div class="margin-top">
         <button class="btn btn-secondary" ng-click="calculate()">Calculate</button>
     </div>
-    <p><em>To test type assertions, enter a non-number and check the console</em></p>
+    <p><em>To test type assertions, enter a non-number and click "Calculate"</em></p>
 </section>

--- a/bower.json
+++ b/bower.json
@@ -16,6 +16,7 @@
     "angular": "~1.3.0",
     "angular-mocks": "~1.3.0",
     "bootstrap": "~3.3.0",
-    "angular-ui-router": "~0.2.11"
+    "angular-ui-router": "~0.2.11",
+    "console-log-div": "~0.5.0"
   }
 }


### PR DESCRIPTION
Makes results obvious and removes need to open browser console to see runtime error.
![screen shot 2015-02-10 at 3 06 00 pm](https://cloud.githubusercontent.com/assets/2212006/6135475/f51ac66a-b136-11e4-9ec9-a9ccf7ae450a.png)
